### PR TITLE
feat: add Advent of Cyber

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ A list of coding Advent Calendars for 2021, with snippets from the websites that
 [Advent of Code](https://adventofcode.com/)
 "Advent of Code is an Advent calendar of small programming puzzles for a variety of skill sets and skill levels that can be solved in any programming language you like. People use them as a speed contest, interview prep, company training, university coursework, practice problems, or to challenge each other."
 
+[Advent of Cyber](https://tryhackme.com/christmas/)
+"Advent of Cyber is an event that gets people started in cyber security, by releasing beginner friendly security exercises every day leading up to Christmas. Each task is self contained and includes the basic information required to start working on a security challenge."
+
 [Advent of GraphQL](https://www.notion.so/Advent-of-GraphQL-c69086ae98764e2e9e1ccdd8938dc980)
 "If you're curious about GraphQL, but only have ~5 minutes a day to learn it, we've got a project for you! A new challenge is unlocked every day."
 
 [Advent of JS](https://www.adventofjs.com/)
 "The best way to learn is through real world projects and components. Build things! Practice. Challenge yourself. Not sure what to build? With Advent of JavaScript, you'll get 24 challenges via email, every day, December 1 - 24, 2021."
-
-
-


### PR DESCRIPTION
Wasn't sure how you want to sort them, I add it in alphabetical order. 

Add [Advent of Cyber](https://tryhackme.com/christmas/) on the list, and a short snippet cut from here:

> **What is Advent of Cyber?**
> 
> Advent of Cyber is an event that gets people started in cyber security, by releasing beginner friendly security exercises every day leading up to Christmas.
> 
> We know that security can be a daunting field, and can be difficult for beginners to get started. Advent of Cyber helps you kick start your security journey.
> 
> For 25 days we release tasks breaking down common security topics into byte-sized walkthroughs and challenges.
> 
> Each task is self contained and includes the basic information required to start working on a security challenge - We won't be throwing you in the deep end, every challenge will contain supporting material and a video tutorial!